### PR TITLE
Google: Add an AllowedDomains config clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ func init() {
   Auth.RegisterProvider(google.New(&google.Config{
     ClientID:     "google client id",
     ClientSecret: "google client secret",
+    AllowedDomains: []string{}, // Accept all domains, instead you can pass a whitelist of acceptable domains
   }))
 
   // Allow use Facebook


### PR DESCRIPTION
By default, qor's google integration accepts all domains. In some cases
it might be useful to authenticate against google app domains from one
or more organizations.

If AllowedDomains is empty the behavior is unchanged but if it is set,
only emails that are contained in that slice are accepted.