### PR TITLE
Fixed：Unknown column 'basics.provider' in 'where clause')?

### DIFF
--- a/providers/password/confirm.go
+++ b/providers/password/confirm.go
@@ -64,7 +64,7 @@ var DefaultConfirmationMailer = func(email string, context *auth.Context, claims
 // DefaultConfirmHandler default confirm handler
 var DefaultConfirmHandler = func(context *auth.Context) error {
 	var (
-		authInfo    auth_identity.Basic
+		authInfo    auth_identity.AuthIdentity
 		provider, _ = context.Provider.(*Provider)
 		tx          = context.Auth.GetDB(context.Request)
 		token       = context.Request.URL.Query().Get("token")

--- a/providers/password/handlers.go
+++ b/providers/password/handlers.go
@@ -14,7 +14,7 @@ import (
 // DefaultAuthorizeHandler default authorize handler
 var DefaultAuthorizeHandler = func(context *auth.Context) (*claims.Claims, error) {
 	var (
-		authInfo    auth_identity.Basic
+		authInfo    auth_identity.AuthIdentity
 		req         = context.Request
 		tx          = context.Auth.GetDB(req)
 		provider, _ = context.Provider.(*Provider)

--- a/providers/password/handlers.go
+++ b/providers/password/handlers.go
@@ -48,7 +48,7 @@ var DefaultRegisterHandler = func(context *auth.Context) (*claims.Claims, error)
 		err         error
 		currentUser interface{}
 		schema      auth.Schema
-		authInfo    auth_identity.Basic
+		authInfo    auth_identity.AuthIdentity
 		req         = context.Request
 		tx          = context.Auth.GetDB(req)
 		provider, _ = context.Provider.(*Provider)


### PR DESCRIPTION
When the provider is password,we will create the auth_identitys table using:
`  gormDB.AutoMigrate(&auth_identity.AuthIdentity{})`
If the variable authInfo declared as auth_identity.Basic,will cause 
`	if !tx.Model(context.Auth.AuthIdentityModel).Where(authInfo).Scan(&authInfo).RecordNotFound() {
		return nil, auth.ErrInvalidAccount
	}`
error.
So,the variable authInfo must declare as auth_identity.AuthIdentity.