### PR TITLE
Readme: add missing import and handle error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,70 +20,72 @@ Here is an example:
 package main
 
 import (
-  "github.com/qor/auth"
-  "github.com/qor/auth/auth_identity"
-  "github.com/qor/auth/providers/github"
-  "github.com/qor/auth/providers/google"
-  "github.com/qor/auth/providers/password"
-  "github.com/qor/auth/providers/facebook"
-  "github.com/qor/auth/providers/twitter"
-  "github.com/qor/session/manager"
+	"log"
+	"net/http"
 
-  _ "github.com/mattn/go-sqlite3"
+	"github.com/qor/auth"
+	"github.com/qor/auth/auth_identity"
+	"github.com/qor/auth/providers/facebook"
+	"github.com/qor/auth/providers/github"
+	"github.com/qor/auth/providers/google"
+	"github.com/qor/auth/providers/password"
+	"github.com/qor/auth/providers/twitter"
+	"github.com/qor/session/manager"
 
-  "net/http"
+	"github.com/jinzhu/gorm"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
-  // Initialize gorm DB
-  gormDB, _ = gorm.Open("sqlite3", "sample.db")
+	// Initialize gorm DB
+	gormDB, _ = gorm.Open("sqlite3", "sample.db")
 
-  // Initialize Auth with configuration
-  Auth = auth.New(&auth.Config{
-    DB: gormDB,
-  })
+	// Initialize Auth with configuration
+	Auth = auth.New(&auth.Config{
+		DB: gormDB,
+	})
 )
 
 func init() {
-  // Migrate AuthIdentity model, AuthIdentity will be used to save auth info, like username/password, oauth token, you could change that.
-  gormDB.AutoMigrate(&auth_identity.AuthIdentity{})
+	// Migrate AuthIdentity model, AuthIdentity will be used to save auth info, like username/password, oauth token, you could change that.
+	gormDB.AutoMigrate(&auth_identity.AuthIdentity{})
 
-  // Register Auth providers
-  // Allow use username/password
-  Auth.RegisterProvider(password.New(&password.Config{}))
+	// Register Auth providers
+	// Allow use username/password
+	Auth.RegisterProvider(password.New(&password.Config{}))
 
-  // Allow use Github
-  Auth.RegisterProvider(github.New(&github.Config{
-    ClientID:     "github client id",
-    ClientSecret: "github client secret",
-  }))
+	// Allow use Github
+	Auth.RegisterProvider(github.New(&github.Config{
+		ClientID:     "github client id",
+		ClientSecret: "github client secret",
+	}))
 
-  // Allow use Google
-  Auth.RegisterProvider(google.New(&google.Config{
-    ClientID:     "google client id",
-    ClientSecret: "google client secret",
-    AllowedDomains: []string{}, // Accept all domains, instead you can pass a whitelist of acceptable domains
-  }))
+	// Allow use Google
+	Auth.RegisterProvider(google.New(&google.Config{
+		ClientID:       "google client id",
+		ClientSecret:   "google client secret",
+		AllowedDomains: []string{}, // Accept all domains, instead you can pass a whitelist of acceptable domains
+	}))
 
-  // Allow use Facebook
-  Auth.RegisterProvider(facebook.New(&facebook.Config{
-    ClientID:     "facebook client id",
-    ClientSecret: "facebook client secret",
-  }))
+	// Allow use Facebook
+	Auth.RegisterProvider(facebook.New(&facebook.Config{
+		ClientID:     "facebook client id",
+		ClientSecret: "facebook client secret",
+	}))
 
-  // Allow use Twitter
-  Auth.RegisterProvider(twitter.New(&twitter.Config{
-    ClientID:     "twitter client id",
-    ClientSecret: "twitter client secret",
-  }))
+	// Allow use Twitter
+	Auth.RegisterProvider(twitter.New(&twitter.Config{
+		ClientID:     "twitter client id",
+		ClientSecret: "twitter client secret",
+	}))
 }
 
 func main() {
-  mux := http.NewServeMux()
+	mux := http.NewServeMux()
 
-  // Mount Auth to Router
-  mux.Handle("/auth/", Auth.NewServeMux())
-  http.ListenAndServe(":9000", manager.SessionManager.Middleware(mux))
+	// Mount Auth to Router
+	mux.Handle("/auth/", Auth.NewServeMux())
+	log.Fatal(http.ListenAndServe(":9000", manager.SessionManager.Middleware(mux)))
 }
 ```
 


### PR DESCRIPTION
The main example was missing gorm import and http.ListenAndServe
wasn't handling error. If port 9000 were to already be in use, it would
fail silently.